### PR TITLE
Use PRODUCT_DIR to define where to copy the native libjabra file

### DIFF
--- a/nodesdk/binding.gyp
+++ b/nodesdk/binding.gyp
@@ -57,11 +57,7 @@
               "copies":
               [
                   {
-                    'destination': '<(module_root_dir)/build/Release',
-                    'files': ['<(module_root_dir)/libjabra/windows/x86/libjabra.dll']
-                  },
-                  {
-                    'destination': '<(module_root_dir)/build/Debug',
+                    'destination': '<(PRODUCT_DIR)',
                     'files': ['<(module_root_dir)/libjabra/windows/x86/libjabra.dll']
                   }
               ]
@@ -71,11 +67,7 @@
               "copies":
               [
                   {
-                    'destination': '<(module_root_dir)/build/Release',
-                    'files': ['<(module_root_dir)/libjabra/windows/x64/libjabra.dll']
-                  },
-                  {
-                    'destination': '<(module_root_dir)/build/Debug',
+                    'destination': '<(PRODUCT_DIR)',
                     'files': ['<(module_root_dir)/libjabra/windows/x64/libjabra.dll']
                   }
               ]
@@ -98,11 +90,7 @@
           "copies":
           [
             {
-              'destination': '<(module_root_dir)/build/Release',
-              'files': ['<(module_root_dir)/<(jabralibfolder)/<(jabralibfile)']
-            },
-            {
-              'destination': '<(module_root_dir)/build/Debug',
+              'destination': '<(PRODUCT_DIR)',
               'files': ['<(module_root_dir)/<(jabralibfolder)/<(jabralibfile)']
             }
           ],
@@ -127,11 +115,7 @@
          "copies":
          [
             {
-              'destination': '<(module_root_dir)/build/Release',
-              'files': ['<(module_root_dir)/libjabra/mac/libjabra.dylib']
-            },
-            {
-              'destination': '<(module_root_dir)/build/Debug',
+              'destination': '<(PRODUCT_DIR)',
               'files': ['<(module_root_dir)/libjabra/mac/libjabra.dylib']
             }
          ],


### PR DESCRIPTION
Current binding.gyp copies the native libjabra to both build/Release and build/Debug. With this change the file is copied to the folder matching the current build configuration using the variable PRODUCT_DIR. For more information about node-gyp variables: https://gyp.gsrc.io/docs/InputFormatReference.md#Predefined-Variables