### PR TITLE
Updating Node-gyp bindings file

### DIFF
--- a/nodesdk/binding.gyp
+++ b/nodesdk/binding.gyp
@@ -2,12 +2,14 @@
   "variables": {
     "conditions": [
       ["OS=='win' and target_arch=='ia32'", {
-        "jabralibfolder": "libjabra/windows/x86/libjabra.lib",
-        "jabralibfile": "libjabra.dll"
+        "jabralibfolder": "libjabra/windows/x86",
+        "jabralibfile": "libjabra.dll",
+        "jabraliblibrary": "libjabra.lib"
       }],
       ["OS=='win' and target_arch=='x64'", {
-        "jabralibfolder": "libjabra/windows/x64/libjabra.lib",
-        "jabralibfile": "libjabra.dll"
+        "jabralibfolder": "libjabra/windows/x64",
+        "jabralibfile": "libjabra.dll",
+        "jabraliblibrary": "libjabra.lib"
       }],
       ["OS=='mac'", {
         "jabralibfolder": "../libjabra/mac/libjabra.dylib",
@@ -53,22 +55,22 @@
         ['OS=="win"', {
           'conditions': [
             ['target_arch=="ia32"', {
-              'libraries': [ 'libjabra/windows/x86/libjabra.lib' ],
+              'libraries': [ '<(jabralibfolder)/<(jabraliblibrary)' ],
               "copies":
               [
                   {
                     'destination': '<(PRODUCT_DIR)',
-                    'files': ['<(module_root_dir)/libjabra/windows/x86/libjabra.dll']
+                    'files': ['<(module_root_dir)/<(jabralibfolder)/<(jabralibfile)']
                   }
               ]
             }],
             ['target_arch=="x64"', {
-              'libraries': [ 'libjabra/windows/x64/libjabra.lib' ],
+              'libraries': [ '<(jabralibfolder)/<(jabraliblibrary)' ],
               "copies":
               [
                   {
                     'destination': '<(PRODUCT_DIR)',
-                    'files': ['<(module_root_dir)/libjabra/windows/x64/libjabra.dll']
+                    'files': ['<(module_root_dir)/<(jabralibfolder)/<(jabralibfile)']
                   }
               ]
             }]

--- a/nodesdk/binding.gyp
+++ b/nodesdk/binding.gyp
@@ -12,7 +12,7 @@
         "jabraliblibrary": "libjabra.lib"
       }],
       ["OS=='mac'", {
-        "jabralibfolder": "../libjabra/mac/libjabra.dylib",
+        "jabralibfolder": "libjabra/mac",
         "jabralibfile": "libjabra.dylib"
       }],
       ["OS=='linux' and target_arch=='ia32'", {
@@ -98,7 +98,7 @@
           ],
         }],
         ['OS=="mac"', {
-         'libraries': [ '../libjabra/mac/libjabra.dylib' ],
+         'libraries': [ '../<(jabralibfolder)/<(jabralibfile)' ],
          'xcode_settings': {
            'ld_version_details': 'true',
            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
@@ -118,7 +118,7 @@
          [
             {
               'destination': '<(PRODUCT_DIR)',
-              'files': ['<(module_root_dir)/libjabra/mac/libjabra.dylib']
+              'files': ['<(module_root_dir)/<(jabralibfolder)/<(jabralibfile)']
             }
          ],
          'postbuilds': [

--- a/nodesdk/binding.gyp
+++ b/nodesdk/binding.gyp
@@ -17,11 +17,13 @@
       }],
       ["OS=='linux' and target_arch=='ia32'", {
         "jabralibfolder": "libjabra/ubuntu/x32",
-        "jabralibfile": "libjabra.so.1.8.7.12"
+        "jabralibfileglob": "libjabra.so.*",
+        "jabralibfile": "<!(find '<(_jabralibfolder)' -type f -name '<(_jabralibfileglob)' -printf '%f')"
       }],
       ["OS=='linux' and target_arch=='x64'", {
         "jabralibfolder": "libjabra/ubuntu/x64",
-        "jabralibfile": "libjabra.so.1.8.7.12"
+        "jabralibfileglob": "libjabra.so.*",
+        "jabralibfile": "<!(find '<(_jabralibfolder)' -type f -name '<(_jabralibfileglob)' -printf '%f')"
       }],
       ["OS=='linux' and target_arch=='arm'", {
         "jabralibfolder": "TODO",


### PR DESCRIPTION
The `bindings.gyp` could definitely use some love. This is a small refactoring, aiming to:
- Use variables for Windows and Mac too.
- Get rid of the version number on Linux.